### PR TITLE
:sparkles: Support docker-in-docker

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - run: pip install poetry
+      - run: pipx install poetry
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -6,9 +6,29 @@ RUN apt-get update \
         unminimize \
     && yes | unminimize \
     && apt-get install --yes \
+        ca-certificates \
         man-db \
         manpages-posix \
     && apt-get upgrade --yes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb \
+        [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+        https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+    | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update \
+    && apt-get install --yes \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,17 @@ services:
     stdin_open: true
     tty: true
     network_mode: host
+    working_dir: ${HOME}
+    user: ${USER_ID}:${DEFAULT_GROUP_ID}
+    group_add:
+      - ${SUDO_GROUP_ID}
+      - ${DOCKER_GROUP_ID}
+    environment:
+      TERM: ${TERM}
     volumes:
+      - type: bind
+        source: ${HOME}
+        target: /home/${USERNAME}
       - type: bind
         source: /etc/passwd
         target: /etc/passwd
@@ -44,6 +54,9 @@ services:
         source: /etc/sudoers.d
         target: /etc/sudoers.d
         read_only: true
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
 
   user:
     depends_on: [dev]

--- a/start-container.sh
+++ b/start-container.sh
@@ -3,10 +3,14 @@
 set -euo pipefail
 
 USERNAME=$(whoami)
+export USERNAME
 USER_ID=$(id -u)
-GROUP_ID=$(id -g)
+export USER_ID
+DEFAULT_GROUP_ID=$(id -g)
+export DEFAULT_GROUP_ID
+DOCKER_GROUP_ID=$(getent group docker | cut -d: -f3)
+export DOCKER_GROUP_ID
+SUDO_GROUP_ID=$(getent group sudo | cut -d: -f3)
+export SUDO_GROUP_ID
 
-docker compose run --rm --remove-orphans --build \
-    --volume "${HOME}":/home/"${USERNAME}" --workdir "${HOME}" \
-    --user "${USER_ID}":"${GROUP_ID}" \
-    --env TERM="${TERM}" "${@:2}" "$1"
+docker compose run --rm --remove-orphans --build "${@:2}" "$1"


### PR DESCRIPTION
Problem:
- If the project that I'm working on uses docker, having to interact with that at the host level while everything else happens at the dev container level is inconvenient.
- There are options that are passed via the command line that could be set via the compose file. The compose file is usually preferable.

Solution:
- Install docker in the container and pass through the docker socket and the docker group.
- Clean up start script such that almost all its options are in the compose file.