### PR TITLE
⚡ Improve performance of apt installs 

### DIFF
--- a/Dockerfile.user.example
+++ b/Dockerfile.user.example
@@ -1,11 +1,11 @@
 FROM dev
 
 # Your favorite tools
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         ack \
         atop \
         dtrx \
-        jq \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        jq

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -25,9 +25,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN wget --output-document=- https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && apt-add-repository 'deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic main' \
-    && apt-add-repository 'deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-18 main' \
-    && apt-add-repository 'deb http://apt.llvm.org/mantic/ llvm-toolchain-mantic-19 main'
+    && apt-add-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble main' \
+    && apt-add-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main' \
+    && apt-add-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main'
 RUN apt-get update \
     && apt-get install --yes \
         clang-17 \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,34 +1,36 @@
 FROM run
 
 # Precursors
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         apt-transport-https \
         curl \
         gnupg \
         software-properties-common \
-        wget \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        wget
 
 # C++
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         g++-12 \
         gcc-12 \
         g++-14 \
         gcc-13 \
         g++-13 \
-        gcc-14 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        gcc-14
 
 RUN wget --output-document=- https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-add-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble main' \
     && apt-add-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main' \
     && apt-add-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main'
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         clang-17 \
         clang-format-17 \
@@ -44,9 +46,7 @@ RUN apt-get update \
         clang-format-19 \
         clang-tidy-19 \
         clang-tools-19 \
-        clangd-19 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        clangd-19
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 17 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 18 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 19
@@ -71,15 +71,16 @@ RUN update-alternatives --install /usr/bin/git-clang-format git-clang-format /us
 
 RUN curl --fail --silent --show-error --location https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/bazel.gpg \
     && echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         bazel \
         cmake \
         cppcheck \
         cpplint \
         iwyu \
-        ninja-build \
-    && apt-get clean
+        ninja-build
 
 # Rust
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -93,7 +94,9 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
 
 # Python
 RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         python3 \
         python3-dev \
@@ -101,8 +104,9 @@ RUN apt-get update \
         python3.11 \
         python3.11-dev \
         python3.11-venv \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        python3.10 \
+        python3.10-dev \
+        python3.10-venv
 ENV POETRY_HOME=/usr/local/poetry \
     PATH=/usr/local/poetry/bin:$PATH
 RUN curl --silent --show-error --location https://install.python-poetry.org | python3 - \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,17 +1,16 @@
 FROM build
 
 # Make system human-friendly
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         unminimize \
     && yes | unminimize \
     && apt-get install --yes \
         ca-certificates \
         man-db \
-        manpages-posix \
-    && apt-get upgrade --yes \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        manpages-posix
 
 # Docker
 RUN install -m 0755 -d /etc/apt/keyrings \
@@ -22,19 +21,21 @@ RUN install -m 0755 -d /etc/apt/keyrings \
         https://download.docker.com/linux/ubuntu \
         $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
     | tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         docker-ce \
         docker-ce-cli \
         containerd.io \
         docker-buildx-plugin \
-        docker-compose-plugin \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        docker-compose-plugin
 
 # Developer tools
 RUN add-apt-repository ppa:git-core/ppa
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         bash-completion \
         emacs \
@@ -48,6 +49,4 @@ RUN apt-get update \
         time \
         tmux \
         tree \
-        vim \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        vim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Jonathan Gopel <jgopel@gmail.com>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "~3.12"


### PR DESCRIPTION
Problem:
- The majority of the time for this container is from `apt-get
  install`s. Part of this is in repeated work which is being repeated to
  keep container sizes down.

Solution:
- Use cache mounts for apt data so that builds don't have to do as much
  repetitive work within the build and between builds.