### PR TITLE
:sparkles: Set default service for starting container

### DIFF
--- a/attach-to-container.sh
+++ b/attach-to-container.sh
@@ -3,16 +3,17 @@
 set -euo pipefail
 
 CONTAINER_NAME=dev-container
+SERVICE="${1:-user}"
 
 if docker inspect "${CONTAINER_NAME}" > /dev/null 2>&1; then
     if docker inspect -f '{{.State.Status}}' "${CONTAINER_NAME}" | grep -q "running"; then
         echo "Attaching to ${CONTAINER_NAME}"
     else
         echo "Starting ${CONTAINER_NAME}"
-        ./start-container.sh "$1" --detach --name "${CONTAINER_NAME}"
+        ./start-container.sh "${SERVICE}" --detach --name "${CONTAINER_NAME}"
     fi
 else
     echo "Starting ${CONTAINER_NAME}"
-    ./start-container.sh "$1" --detach --name "${CONTAINER_NAME}"
+    ./start-container.sh "${SERVICE}" --detach --name "${CONTAINER_NAME}"
 fi
 docker exec -it "${CONTAINER_NAME}" bash

--- a/start-container.sh
+++ b/start-container.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+SERVICE="${1:-user}"
+
 USERNAME=$(whoami)
 export USERNAME
 USER_ID=$(id -u)
@@ -13,4 +15,4 @@ export DOCKER_GROUP_ID
 SUDO_GROUP_ID=$(getent group sudo | cut -d: -f3)
 export SUDO_GROUP_ID
 
-docker compose run --rm --remove-orphans --build "${@:2}" "$1"
+docker compose run --rm --remove-orphans --build "${@:2}" "${SERVICE}"


### PR DESCRIPTION
Problem:
- The startup scripts are missing a sensible default. The user should not be expected to know/remember the names of the services if they're in the expected use-case.