### PR TITLE
:bug: Allow installation inside the container

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -7,6 +7,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install --yes \
         unminimize \
     && yes | unminimize \
+    && apt-get remove --yes \
+        postfix
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
     && apt-get install --yes \
         ca-certificates \
         man-db \


### PR DESCRIPTION
Problem:
- `postfix` blocks installation of packages during the dev workflow. This is unhelpful because it's often the case that manual package installation is a good way of trialing new features before integrating them into the container.

Solution:
- Remove `postfix` after it's installed.
- Also split the layers. Now that I'm doing caching, having more, smaller layers gives better build caching.