### PR TITLE
:sparkles: Install bleeding edge CMake

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -71,6 +71,8 @@ RUN update-alternatives --install /usr/bin/git-clang-format git-clang-format /us
 
 RUN curl --fail --silent --show-error --location https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/bazel.gpg \
     && echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+RUN wget --output-document=- https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+    && apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release --codename --short) main"
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update \


### PR DESCRIPTION
Problem:
- The version of `cmake` available in the standard apt repos isn't all that recent.

Solution:
- Add KitWare's CMake repo prior to CMake installation.