### PR TITLE
:bug: Build services in order before launching

### DIFF
--- a/start-container.sh
+++ b/start-container.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SERVICE="${1:-user}"
+TARGET_SERVICE="${1:-user}"
 
 USERNAME=$(whoami)
 export USERNAME
@@ -15,4 +15,11 @@ export DOCKER_GROUP_ID
 SUDO_GROUP_ID=$(getent group sudo | cut -d: -f3)
 export SUDO_GROUP_ID
 
-docker compose run --rm --remove-orphans --build "${@:2}" "${SERVICE}"
+for service in "run" "build" "dev" "user"; do
+    docker compose build "${service}"
+    if [[ "${service}" == "${TARGET_SERVICE}" ]]; then
+        break
+    fi
+done
+
+docker compose run --rm --remove-orphans --build "${@:2}" "${TARGET_SERVICE}"


### PR DESCRIPTION
Problem:
- Newer versions of `docker compose` don't use `depends-on` in the compose file to dictate build order - they build everything simultaneously and then start services in the order specified by `depends-on`. This is a more efficient approach for building services, but it breaks the ordering here. Builds where there is no cache no longer work. Builds where there is a cache use outdated containers for the base containers.

Solution:
- When starting a container, build all the containers it depends on first. This ensures that things are never based on stale versions of parent containers and that cold builds work.